### PR TITLE
Add Windows service registration and unregistration commands

### DIFF
--- a/CrashpadKiller/CrashpadKiller.csproj
+++ b/CrashpadKiller/CrashpadKiller.csproj
@@ -20,6 +20,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.6" />
       <PackageReference Include="NLog" Version="5.5.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>

--- a/CrashpadKiller/Program.cs
+++ b/CrashpadKiller/Program.cs
@@ -3,156 +3,229 @@ using System.Diagnostics;
 using System.Xml.Linq;
 using NLog;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
-var intervalOption = new Option<int>(
-    name: "--interval",
-    description: "Execution interval in seconds.")
+public class Program
 {
-    IsRequired = true
-};
-
-var rootCommand = new RootCommand("CrashpadKiller");
-
-var oneshotCommand = new Command("oneshot", "Run in an oneshot mode.");
-var daemonCommand = new Command("daemon", "Run in a daemon mode.");
-var registerCommand = new Command("register", "Register as a Windows service.");
-var unregisterCommand = new Command("unregister", "Unregister the Windows service.");
-
-daemonCommand.AddOption(intervalOption);
-daemonCommand.SetHandler(ProcessLoop, intervalOption);
-
-oneshotCommand.SetHandler(Execute);
-
-registerCommand.AddOption(intervalOption);
-registerCommand.SetHandler(RegisterService, intervalOption);
-unregisterCommand.SetHandler(UnregisterService);
-
-rootCommand.Add(oneshotCommand);
-rootCommand.Add(daemonCommand);
-rootCommand.Add(registerCommand);
-rootCommand.Add(unregisterCommand);
-
-Config.Targets = LoadTargetsFromConfig();
-
-return await rootCommand.InvokeAsync(args);
-
-void ProcessLoop(int intervalSeconds)
-{
-    if (intervalSeconds <= 0) return;
-    while (true)
+    public static async Task Main(string[] args)
     {
-        Execute();
-        Thread.Sleep(intervalSeconds * 1000);
-    }
-}
-
-List<string> LoadTargetsFromConfig()
-{
-    try
-    {
-        using var configFile = new StreamReader("process.xml");
-        var config = XDocument.Parse(configFile.ReadToEnd());
-        var processTree = config.Element("config")?.Element("processes");
-        var targetProcesses = processTree?.Elements("process");
-        if (targetProcesses != null)
-            return targetProcesses.Select(target => target.Value).ToList();
-        throw new InvalidProcessConfigurationFileException("No process targets found in configuration.");
-    }
-    catch (Exception ex)
-    {
-        throw new InvalidProcessConfigurationFileException("Failed to load process configuration.", ex);
-    }
-}
-
-void Execute()
-{
-    var logger = LogManager.GetCurrentClassLogger();
-
-    logger.Info("Killing those pesky crashpads.");
-    logger.Info("Targets are:");
-    if (Config.Targets != null && Config.Targets.Count > 0)
-    {
-        foreach (var target in Config.Targets)
+        try
         {
-            logger.Info(target);
+            Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+            if (args.Length == 0 && OperatingSystem.IsWindows())
+            {
+                int interval = 60; // Default interval
+                if (Config.Targets == null)
+                    Config.Targets = LoadTargetsFromConfig();
+                var host = Host.CreateDefaultBuilder()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddHostedService(_ => new CrashpadKillerWorker(interval));
+                    })
+                    .UseWindowsService()
+                    .Build();
+                await host.RunAsync();
+                return;
+            }
+
+            var intervalOption = new Option<int>(
+                name: "--interval",
+                description: "Execution interval in seconds.")
+            {
+                IsRequired = true
+            };
+
+            var rootCommand = new RootCommand("CrashpadKiller");
+
+            var oneshotCommand = new Command("oneshot", "Run in an oneshot mode.");
+            var daemonCommand = new Command("daemon", "Run in a daemon mode.");
+            var registerCommand = new Command("register", "Register as a Windows service.");
+            var unregisterCommand = new Command("unregister", "Unregister the Windows service.");
+
+            daemonCommand.AddOption(intervalOption);
+            daemonCommand.SetHandler(ProcessLoop, intervalOption);
+
+            oneshotCommand.SetHandler(Execute);
+
+            registerCommand.AddOption(intervalOption);
+            registerCommand.SetHandler(RegisterService, intervalOption);
+            unregisterCommand.SetHandler(UnregisterService);
+
+            rootCommand.Add(oneshotCommand);
+            rootCommand.Add(daemonCommand);
+            rootCommand.Add(registerCommand);
+            rootCommand.Add(unregisterCommand);
+
+            Config.Targets = LoadTargetsFromConfig();
+
+            await rootCommand.InvokeAsync(args);
         }
-
-        var processes = Process.GetProcesses();
-        var executionTargets = processes.Where(p => Config.Targets.Contains(p.ProcessName)).ToList();
-
-        foreach (var proc in executionTargets)
+        catch (Exception ex)
         {
-            try
-            {
-                logger.Debug($"Attempting to kill {proc.ProcessName} (PID: {proc.Id})");
-                proc.Kill(false);
-            }
-            catch (Exception ex)
-            {
-                logger.Warn($"Failed to kill {proc.ProcessName} (PID: {proc.Id}): {ex.Message}");
-            }
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Fatal(ex, "Fatal error in Main");
+            throw;
         }
     }
-    else
+
+    private static void ProcessLoop(int intervalSeconds)
     {
-        logger.Warn("No targets specified in configuration.");
+        if (intervalSeconds <= 0) return;
+        while (true)
+        {
+            Execute();
+            Thread.Sleep(intervalSeconds * 1000);
+        }
     }
 
-    logger.Info("Process complete.");
-    LogManager.Shutdown();
-}
-
-void RegisterService(int interval)
-{
-    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    private static List<string> LoadTargetsFromConfig()
     {
-        Console.WriteLine("Service registration is only supported on Windows.");
-        return;
+        try
+        {
+            var baseDir = AppContext.BaseDirectory;
+            var configPath = Path.Combine(baseDir, "process.xml");
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Info($"Looking for process.xml at: {configPath}");
+            if (!File.Exists(configPath))
+            {
+                logger.Error($"Config file not found: {configPath}");
+                throw new InvalidProcessConfigurationFileException($"Config file not found: {configPath}");
+            }
+            using var configFile = new StreamReader(configPath);
+            var config = XDocument.Parse(configFile.ReadToEnd());
+            var processTree = config.Element("config")?.Element("processes");
+            var targetProcesses = processTree?.Elements("process");
+            if (targetProcesses != null)
+                return targetProcesses.Select(target => target.Value).ToList();
+            throw new InvalidProcessConfigurationFileException("No process targets found in configuration.");
+        }
+        catch (Exception ex)
+        {
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Error(ex, "Failed to load process configuration.");
+            throw new InvalidProcessConfigurationFileException("Failed to load process configuration.", ex);
+        }
     }
-    if (interval <= 0)
-    {
-        Console.WriteLine("Interval must be greater than 0.");
-        return;
-    }
-    var exePath = Process.GetCurrentProcess().MainModule?.FileName;
-    if (string.IsNullOrEmpty(exePath))
-    {
-        Console.WriteLine("Failed to get executable path.");
-        return;
-    }
-    const string serviceName = "CrashpadKiller";
-    const string displayName = "CrashpadKiller Service";
-    var args = $"create {serviceName} binPath= \"{exePath} daemon --interval {interval}\" DisplayName= \"{displayName}\" start= auto";
-    var psi = new ProcessStartInfo("sc.exe", args) { RedirectStandardOutput = true, UseShellExecute = false };
-    var proc = Process.Start(psi);
-    proc?.WaitForExit();
-    Console.WriteLine(proc?.StandardOutput.ReadToEnd());
-}
 
-void UnregisterService()
-{
-    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    private static void Execute()
     {
-        Console.WriteLine("Service unregistration is only supported on Windows.");
-        return;
+        var logger = LogManager.GetCurrentClassLogger();
+
+        logger.Info("Killing those pesky crashpads.");
+        logger.Info("Targets are:");
+        if (Config.Targets != null && Config.Targets.Count > 0)
+        {
+            foreach (var target in Config.Targets)
+            {
+                logger.Info(target);
+            }
+
+            var processes = Process.GetProcesses();
+            var executionTargets = processes.Where(p => Config.Targets.Contains(p.ProcessName)).ToList();
+
+            foreach (var proc in executionTargets)
+            {
+                try
+                {
+                    logger.Debug($"Attempting to kill {proc.ProcessName} (PID: {proc.Id})");
+                    proc.Kill(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"Failed to kill {proc.ProcessName} (PID: {proc.Id}): {ex.Message}");
+                }
+            }
+        }
+        else
+        {
+            logger.Warn("No targets specified in configuration.");
+        }
+
+        logger.Info("Process complete.");
+        LogManager.Shutdown();
     }
-    const string serviceName = "CrashpadKiller";
-    var args = $"delete {serviceName}";
-    var psi = new ProcessStartInfo("sc.exe", args) { RedirectStandardOutput = true, UseShellExecute = false };
-    var proc = Process.Start(psi);
-    proc?.WaitForExit();
-    Console.WriteLine(proc?.StandardOutput.ReadToEnd());
-}
 
-internal static class Config
-{
-    internal static List<string>? Targets { get; set; }
-}
-
-public class InvalidProcessConfigurationFileException : Exception
-{
-    public InvalidProcessConfigurationFileException(string? message = null, Exception? inner = null)
-        : base(message, inner)
+    private static void RegisterService(int interval)
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Console.WriteLine("Service registration is only supported on Windows.");
+            return;
+        }
+        if (interval <= 0)
+        {
+            Console.WriteLine("Interval must be greater than 0.");
+            return;
+        }
+        var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+        if (string.IsNullOrEmpty(exePath))
+        {
+            Console.WriteLine("Failed to get executable path.");
+            return;
+        }
+        const string serviceName = "CrashpadKiller";
+        const string displayName = "CrashpadKiller Service";
+        var args = $"create {serviceName} binPath= \"{exePath} daemon --interval {interval}\" DisplayName= \"{displayName}\" start= auto";
+        var psi = new ProcessStartInfo("sc.exe", args) { RedirectStandardOutput = true, UseShellExecute = false };
+        var proc = Process.Start(psi);
+        proc?.WaitForExit();
+        Console.WriteLine(proc?.StandardOutput.ReadToEnd());
+    }
+
+    private static void UnregisterService()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Console.WriteLine("Service unregistration is only supported on Windows.");
+            return;
+        }
+        const string serviceName = "CrashpadKiller";
+        var args = $"delete {serviceName}";
+        var psi = new ProcessStartInfo("sc.exe", args) { RedirectStandardOutput = true, UseShellExecute = false };
+        var proc = Process.Start(psi);
+        proc?.WaitForExit();
+        Console.WriteLine(proc?.StandardOutput.ReadToEnd());
+    }
+
+    internal static class Config
+    {
+        internal static List<string>? Targets { get; set; }
+    }
+
+    public class InvalidProcessConfigurationFileException : Exception
+    {
+        public InvalidProcessConfigurationFileException(string? message = null, Exception? inner = null)
+            : base(message, inner)
+        {
+        }
+    }
+
+    // Worker class for Windows Service/daemon support
+    public class CrashpadKillerWorker : BackgroundService
+    {
+        private readonly int _intervalSeconds;
+        public CrashpadKillerWorker(int intervalSeconds)
+        {
+            _intervalSeconds = intervalSeconds > 0 ? intervalSeconds : 60;
+        }
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Info($"CrashpadKillerWorker started. Interval: {_intervalSeconds}s");
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    Execute();
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Exception in CrashpadKillerWorker loop");
+                }
+                await Task.Delay(_intervalSeconds * 1000, stoppingToken);
+            }
+            logger.Info("CrashpadKillerWorker stopped.");
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to register and unregister the application as a Windows service, along with associated changes to the command-line interface and supporting methods. The most important changes include the addition of new commands, methods for service registration and unregistration, and platform-specific checks.

### Command-line interface enhancements:
* Added two new commands: `register` (to register the application as a Windows service) and `unregister` (to unregister the service). These commands are integrated into the root command and include appropriate handlers. (`CrashpadKiller/Program.cs`, [CrashpadKiller/Program.csR18-R33](diffhunk://#diff-c95a95acfa143e07adb5af62e1959990aabc967ebc7500ed288d1381b562d1f9R18-R33))

### Service registration and unregistration functionality:
* Introduced a `RegisterService(int interval)` method to handle Windows service registration. This method validates the platform, ensures the interval is valid, and constructs the necessary `sc.exe` command to register the service. (`CrashpadKiller/Program.cs`, [CrashpadKiller/Program.csR105-R146](diffhunk://#diff-c95a95acfa143e07adb5af62e1959990aabc967ebc7500ed288d1381b562d1f9R105-R146))
* Added an `UnregisterService()` method to unregister the Windows service by invoking the `sc.exe` command. This method also includes platform checks to ensure compatibility. (`CrashpadKiller/Program.cs`, [CrashpadKiller/Program.csR105-R146](diffhunk://#diff-c95a95acfa143e07adb5af62e1959990aabc967ebc7500ed288d1381b562d1f9R105-R146))

### Platform-specific support:
* Added a `using System.Runtime.InteropServices;` directive to enable platform detection for Windows-specific functionality. (`CrashpadKiller/Program.cs`, [CrashpadKiller/Program.csR5](diffhunk://#diff-c95a95acfa143e07adb5af62e1959990aabc967ebc7500ed288d1381b562d1f9R5))