### PR TITLE
Update Microsoft.NET.Test.Sdk to version 18.5.1

### DIFF
--- a/CrashpadKiller.Tests/CrashpadKiller.Tests.csproj
+++ b/CrashpadKiller.Tests/CrashpadKiller.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
   <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.CommandLine" Version="2.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
This pull request includes a minor update to the test project dependencies. The `Microsoft.NET.Test.Sdk` package was upgraded to version 18.5.1 to ensure compatibility and access to the latest testing features.